### PR TITLE
Add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/shurcooL/sanitized_anchor_name
-
-go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/shurcooL/sanitized_anchor_name
+
+go 1.12


### PR DESCRIPTION
Hello, please consider adding this go.mod file and then creating a tagged release. Just like in #4 I am having this be pulled in as an indirect dependency and would like to be able to keep track of a specific version instead of using an indirect import like:

> github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 // indirect

To be clear: this isn't causing it any problems, I'm just trying to make my `go.mod` file easier to read by getting more projects that I indirectly depend on to support Go Modules.

Thank you for your consideration.