### PR TITLE
Speed up/reduce allocations by using strings.Map

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,23 +7,26 @@
 // are unique, that responsibility falls on the caller.
 package sanitized_anchor_name // import "github.com/shurcooL/sanitized_anchor_name"
 
-import "unicode"
+import (
+	"strings"
+	"unicode"
+)
 
 // Create returns a sanitized anchor name for the given text.
 func Create(text string) string {
-	var anchorName []rune
-	var futureDash = false
-	for _, r := range text {
-		switch {
-		case unicode.IsLetter(r) || unicode.IsNumber(r):
-			if futureDash && len(anchorName) > 0 {
-				anchorName = append(anchorName, '-')
-			}
-			futureDash = false
-			anchorName = append(anchorName, unicode.ToLower(r))
-		default:
-			futureDash = true
+	var hasRunes bool
+	var prevDash bool
+	fn := func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			hasRunes = true
+			prevDash = false
+			return unicode.ToLower(r)
 		}
+		if hasRunes && !prevDash {
+			prevDash = true
+			return '-'
+		}
+		return -1
 	}
-	return string(anchorName)
+	return strings.TrimRight(strings.Map(fn, text), "-")
 }


### PR DESCRIPTION
With the following benchmark:

```go
var sink string

func BenchmarkCreate(b *testing.B) {
	b.Run("Simple", func(b *testing.B) {
		const text = `Strings, bytes, runes and characters in Go`
		b.ReportAllocs()
		b.SetBytes(int64(len(text)))
		for i := 0; i < b.N; i++ {
			sink = sanitized_anchor_name.Create(text)
		}
	})
	b.Run("Complex", func(b *testing.B) {
		const text = `日本語; «Ёжик в тумане»?!`
		b.ReportAllocs()
		b.SetBytes(int64(len(text)))
		for i := 0; i < b.N; i++ {
			sink = sanitized_anchor_name.Create(text)
		}
	})
}
```

The results are:

```
name              old time/op    new time/op     delta
Create/Simple-8      434ns ± 0%      187ns ± 1%   -56.99%  (p=0.000 n=10+10)
Create/Complex-8     667ns ± 0%      579ns ± 0%   -13.26%  (p=0.000 n=10+10)

name              old speed      new speed       delta
Create/Simple-8   96.8MB/s ± 0%  225.0MB/s ± 1%  +132.53%  (p=0.000 n=10+10)
Create/Complex-8  61.5MB/s ± 0%   70.9MB/s ± 0%   +15.30%  (p=0.000 n=10+10)

name              old alloc/op   new alloc/op    delta
Create/Simple-8       552B ± 0%        48B ± 0%   -91.30%  (p=0.000 n=10+10)
Create/Complex-8      296B ± 0%        48B ± 0%   -83.78%  (p=0.000 n=10+10)

name              old allocs/op  new allocs/op   delta
Create/Simple-8       7.00 ± 0%       1.00 ± 0%   -85.71%  (p=0.000 n=10+10)
Create/Complex-8      6.00 ± 0%       1.00 ± 0%   -83.33%  (p=0.000 n=10+10)
```